### PR TITLE
Fix warning/error

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -306,7 +306,6 @@ unsigned int io_seproxyhal_handle_event(void) {
             }
           }
         }
-        __attribute__((fallthrough));
       }
 #endif // HAVE_IO_USB
 #ifdef HAVE_BLE_APDU
@@ -318,9 +317,9 @@ unsigned int io_seproxyhal_handle_event(void) {
             THROW(EXCEPTION_IO_RESET);
           }
         }
-        __attribute__((fallthrough));
       }
 #endif // HAVE_BLE_APDU
+        __attribute__((fallthrough));
       // no break is intentional
     default:
       return io_event(CHANNEL_SPI);


### PR DESCRIPTION
When upgrading compilers (gcc/clang) to cope with a problem in the Nano S SDK 2.0, new compilers complain about the incorrect usage of `fallthrough` in the Nano X SDK.

This problem is blocking us in multiple builds and the fix is very simple. It would be very appreciated if it could get merged.
