### PR TITLE
Fixes for clang 10 and above

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -35,9 +35,15 @@ DEFINES += gcc __IO=volatile
 log = $(if $(strip $(VERBOSE)),$1,@$1)
 
 CC      = clang
+
+SYSROOT = $(shell $(GCCPATH)arm-none-eabi-gcc -print-sysroot)
+ifeq ($(SYSROOT),)
+CFLAGS   += -I/usr/include
+else
+CFLAGS   += --sysroot="$(SYSROOT)"
+endif
 CFLAGS += -gdwarf-2  -gstrict-dwarf
 CFLAGS += -O3 -Os 
-CFLAGS += -I/usr/include
 CFLAGS += -fomit-frame-pointer -momit-leaf-frame-pointer 
 CFLAGS += -mcpu=cortex-m0 -mthumb 
 CFLAGS += -fno-common -mtune=cortex-m0 -mlittle-endian 
@@ -57,7 +63,6 @@ AFLAGS += -ggdb2 -O3 -Os -mcpu=cortex-m0 -fno-common -mtune=cortex-m0
 LDFLAGS += --target=armv6m-none-eabi
 LDFLAGS += -gdwarf-2  -gstrict-dwarf 
 LDFLAGS += -O3 -Os
-LDFLAGS += -I/usr/include
 LDFLAGS += -fomit-frame-pointer -momit-leaf-frame-pointer 
 LDFLAGS += -mno-movt
 LDFLAGS += -Wall 

--- a/script.ld
+++ b/script.ld
@@ -81,7 +81,7 @@ SECTIONS
     _envram = .;
     PROVIDE(_envram = . + ORIGIN(FLASH));
     
-  } > FLASH = 0x00
+  } > FLASH
 
   .data (NOLOAD):
   {
@@ -123,20 +123,20 @@ SECTIONS
     _estack = ABSOLUTE(END_STACK);
     PROVIDE( _estack = ABSOLUTE(END_STACK) );
 
-  } > SRAM = 0x00
+  } > SRAM
 
   /****************************************************************/
   /* DEBUG                                                        */
   /****************************************************************/
 
   /* remove the debugging information from the standard libraries */
-  DEBUG (NOLOAD) :
+  /DISCARD/ :
   {
     libc.a ( * )
     libm.a ( * )
     libgcc.a ( * )
     *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-  } > DISCARD
+  }
 
   /* Stabs debugging sections.  */
   .stab          0 : { *(.stab) }

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -15,6 +15,7 @@
 #include "hci.h"
 #endif // HAVE_BLUENRG
 
+#include "checks.h"
 #include "ux.h"
 
 #ifdef HAVE_IO_U2F
@@ -291,7 +292,6 @@ unsigned int io_seproxyhal_handle_event(void) {
             }
           }
         }
-        __attribute__((fallthrough));
       }
 #endif // HAVE_IO_USB
 #ifdef HAVE_BLE_APDU
@@ -303,10 +303,9 @@ unsigned int io_seproxyhal_handle_event(void) {
             THROW(EXCEPTION_IO_RESET);
           }
         }
-        __attribute__((fallthrough));
       }
 #endif // HAVE_BLE_APDU
-      // no break is intentional
+      __attribute__((fallthrough));
     default:
       return io_event(CHANNEL_SPI);
   }


### PR DESCRIPTION
- Use ARM toolchain sysroot if present
- Move fallthrough attributes at correct places
- Fix link script for compatibility with recent lld