### PR TITLE
Make the PIC macro confuse the type checker less

### DIFF
--- a/include/os_pic.h
+++ b/include/os_pic.h
@@ -8,7 +8,7 @@
 #define PIC(x) (x)
 #endif
 #ifndef PIC
-#define PIC(x) pic((void *)x)
+#define PIC(x) ((typeof(x)) pic((void *)x))
 void *pic(void *linked_address);
 void *pic_internal(void *link_address);
 #endif


### PR DESCRIPTION
Companion to https://github.com/LedgerHQ/nanos-secure-sdk/pull/43